### PR TITLE
Updating Makefile for gcc missing function errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all: bloomlib
-	gcc -O3 -lm bloom.c -o bloom bloomlib.o
+	gcc -O3 bloom.c -lm -o bloom bloomlib.o
 	rm bloomlib.o
 
 bloomlib:


### PR DESCRIPTION
Linking "-lm" after bloom.c so that ld can find the math functions that are
exposed by "-lm" and required by bloom.c. Otherwise ld assumes that functions
exposed by "-lm" are not required (since it finds no references to them).
